### PR TITLE
chore(ci): split demo.yml into build + deploy jobs

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -41,6 +39,20 @@ jobs:
         with:
           path: './demo/dist'
 
+  deploy:
+    name: 🚀 Deploy
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@de14547edc9944350dc0481aa5b7afb08e75f254 # v2


### PR DESCRIPTION
Splits the single build-and-deploy job into the canonical GitHub Pages 2-job pattern: build (no `id-token`) → deploy (only `id-token: write`, runs deploy-pages only).

Resolves the supply-chain audit's OIDC-fused finding on this workflow.