### PR TITLE
chore(ci): split release.yml into build/publish/release-notes/notify jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 permissions:
-  id-token: write  # Required for OIDC
-  contents: write
+  contents: read
 
 on:
   push:
@@ -10,7 +9,7 @@ on:
       - 'v*'
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -23,10 +22,8 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 20
           cache: pnpm
-
 
       - name: 📥 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -42,42 +39,88 @@ jobs:
 
       - name: 📦 Validate build artifacts
         run: |
-          # Check if dist directory exists
           if [ ! -d "dist" ]; then
             echo "❌ dist directory is missing but declared in package.json"
             exit 1
           fi
-
-          # Check if dist contains files
           if [ -z "$(ls -A dist)" ]; then
             echo "❌ dist directory is empty"
             exit 1
           fi
-
-          # Check for index.js and index.d.ts
           if [ ! -f "dist/index.js" ] || [ ! -f "dist/index.d.ts" ]; then
             echo "❌ Missing required files in dist/"
             echo "Required: index.js and index.d.ts"
             echo "Found: $(ls dist)"
             exit 1
           fi
-
           echo "✅ Build artifacts validation passed"
 
+      - name: 📤 Upload package artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package
+          path: |
+            dist/
+            package.json
+            README.md
+            LICENSE
+          retention-days: 1
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+            - name: ⎔ Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 📥 Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package
+
       - name: 📦 Publish to NPM
-        run: pnpm publish --no-git-checks
+        run: pnpm publish --no-git-checks --ignore-scripts
         env:
           NODE_AUTH_TOKEN: "" # Clear placeholder set by setup-node to enable OIDC
+
+  release-notes:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
 
       - name: 📝 Update Changelog
         run: npx changelogithub
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  notify:
+    needs: [build, publish, release-notes]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
       - name: 📣 Notify release result
-        if: always()
         uses: marimo-team/internal-gh-actions/release-notification@ba06d4db1f3c5c9b86983ce409e57196f8376777 # main
         with:
-          status: ${{ job.status }}
+          status: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && 'failure' || 'success' }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
           artifact-url: "https://npmjs.com/package/@marimo-team/blocks"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           cache: pnpm
 
       - name: 📥 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile
 
       - name: 🔍 Type Check
         run: pnpm run typecheck
@@ -109,7 +109,7 @@ jobs:
           node-version: 24
 
       - name: 📝 Update Changelog
-        run: npx changelogithub
+        run: npx changelogithub@14.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Splits the single release job into 4 jobs so the `id-token: write` scope is held only by a publish job that runs `npm publish` exclusively (no install/test/build/exec).

- **build** (no `id-token`): install, typecheck, test, build, validate, upload `dist/` + package metadata as artifact.
- **publish** (`id-token: write`): download artifact, `npm publish --ignore-scripts`.
- **release-notes** (`contents: write`, no `id-token`): `npx changelogithub`.
- **notify** (`if: always()`): slack notification, aggregates `needs.*.result`.

Resolves the supply-chain audit `oidc-publish-fused` finding. Mirrors marimo-team/codemirror-ai#111. Motivated by the TanStack npm supply-chain compromise (May 2026).