### PR TITLE
fix(ci): download artifact before pnpm setup in publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: 📥 Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package
+
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
@@ -82,11 +87,6 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - name: 📥 Download package artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: package
 
       - name: 📦 Publish to NPM
         run: pnpm publish --no-git-checks --ignore-scripts


### PR DESCRIPTION
The `publish` job has no `checkout` step, so `package.json` (with `packageManager`) only exists after the artifact download. Running `pnpm/action-setup` first leaves it with no pnpm version to read — the same failure mode that broke codemirror-sql's release once it moved to action-setup v6 (v4 still has a fallback, so this is latent here).

Fix: reorder so the artifact download runs before pnpm setup.

Also fixes a pre-existing mis-indented `Setup Node.js` step.